### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol (MCP) server that allows AI assistants to interact with Sonic Pi through OSC messages. This enables AI tools like Claude and Cursor to create music and control Sonic Pi programmatically.
 
+<a href="https://glama.ai/mcp/servers/@abhishekjairath/sonic-pi-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@abhishekjairath/sonic-pi-mcp/badge" alt="Sonic Pi MCP server" />
+</a>
+
 ## Features
 
 - Play individual notes with customizable synth parameters


### PR DESCRIPTION
This PR adds a badge for the [Sonic Pi MCP](https://glama.ai/mcp/servers/@abhishekjairath/sonic-pi-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@abhishekjairath/sonic-pi-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@abhishekjairath/sonic-pi-mcp/badge" alt="Sonic Pi MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.